### PR TITLE
Set mixer before playing audio

### DIFF
--- a/ExplosionModule.cs
+++ b/ExplosionModule.cs
@@ -263,6 +263,7 @@
             {
                 source.transform.parent = null;
                 source.transform.position = grenade.transform.position;
+                source.outputAudioMixerGroup = BoneworksModdingToolkit.Audio.sfxMixer;
                 source.Play();
             }
         }


### PR DESCRIPTION
Note, the mixers aren't set when the grenade is loaded as BMT gets the mixer from the player which wouldn't be loaded at that point